### PR TITLE
Fix: Remove flow control shared option when mounting subscription

### DIFF
--- a/jsm/jsm_subscriptions.go
+++ b/jsm/jsm_subscriptions.go
@@ -86,7 +86,6 @@ func (s *subscription) mountSubscription() error {
 			cbHandler,
 			nats.Durable(durableStore),
 			nats.DeliverLast(),
-			nats.EnableFlowControl(),
 			nats.BindStream(s.serviceName),
 			nats.MaxAckPending(20000000),
 			nats.ManualAck(),


### PR DESCRIPTION
### What does this PR do?
 - Fix bug that prevents subscription mounting when `options.Shared` is picked.
### Where should the reviewer start?
 - [jsm/jsm_subscriptions.go](https://github.com/softcomoss/jetstreamclient/compare/fix/queue-subscribe-flow-control?expand=1#diff-34b2a8d73753c1ad46c566fdf011e3397ca23a5adf760952cc35c9e213a3c27d)
### How should this be manually tested?
 - Create a subscription with the shared option.